### PR TITLE
feat: 将 You.com 注册为结构化联网搜索提供程序（带回退）

### DIFF
--- a/App/WebApi/appsettings.Development.json
+++ b/App/WebApi/appsettings.Development.json
@@ -157,5 +157,11 @@
     "Url": "https://dashscope.aliyuncs.com/compatible-api/v1/reranks",
     "DefaultModel": "qwen3-rerank",
     "ApiKey": "***"
+  },
+  //You.com联网搜索
+  "YouCom": {
+    "ApiKey": "",
+    "Url": "https://ydc-index.io/v1/search",
+    "Count": 10
   }
 }

--- a/App/WebApi/appsettings.Test.json
+++ b/App/WebApi/appsettings.Test.json
@@ -157,5 +157,11 @@
     "Url": "https://dashscope.aliyuncs.com/compatible-api/v1/reranks",
     "DefaultModel": "qwen3-rerank",
     "ApiKey": "***"
+  },
+  //You.com联网搜索
+  "YouCom": {
+    "ApiKey": "",
+    "Url": "https://ydc-index.io/v1/search",
+    "Count": 10
   }
 }

--- a/App/WebApi/appsettings.json
+++ b/App/WebApi/appsettings.json
@@ -156,5 +156,11 @@
     "Url": "https://dashscope.aliyuncs.com/compatible-api/v1/reranks",
     "DefaultModel": "qwen3-rerank",
     "ApiKey": "***"
+  },
+  //You.com联网搜索
+  "YouCom": {
+    "ApiKey": "",
+    "Url": "https://ydc-index.io/v1/search",
+    "Count": 10
   }
 }

--- a/Kevin/kevin.Module/kevin.AI.AgentFramework/Tools/HttpClientFunction.cs
+++ b/Kevin/kevin.Module/kevin.AI.AgentFramework/Tools/HttpClientFunction.cs
@@ -62,6 +62,16 @@ namespace kevin.AI.AgentFramework.Tools
         /// </summary> 
         public async Task<string> GetSeoAsync(string value, string aiEndPoint, string aiModelName, string aiModelKey)
         {
+            // 优先使用You.com结构化联网搜索：结果本身已经是干净的结构化文本，
+            // 无需再走HTML抓取+LLM总结的流程。未配置或调用失败时回退到原有抓取逻辑。
+            if (YouComSearchProvider.IsEnabled)
+            {
+                var youComResult = await YouComSearchProvider.SearchAsync(value);
+                if (!string.IsNullOrEmpty(youComResult))
+                {
+                    return "互联网查询信息:" + "\n" + youComResult;
+                }
+            }
 
             var htmls = new List<string>();
             string result = "";

--- a/Kevin/kevin.Module/kevin.AI.AgentFramework/Tools/YouComSearchProvider.cs
+++ b/Kevin/kevin.Module/kevin.AI.AgentFramework/Tools/YouComSearchProvider.cs
@@ -1,0 +1,221 @@
+﻿using Kevin.Common.Helper;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace kevin.AI.AgentFramework.Tools
+{
+    /// <summary>
+    /// You.com 联网搜索配置
+    /// </summary>
+    public class YouComSetting
+    {
+        /// <summary>
+        /// You.com API密钥
+        /// </summary>
+        public string? ApiKey { get; set; }
+
+        /// <summary>
+        /// You.com 搜索接口地址
+        /// </summary>
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// 返回结果数量
+        /// </summary>
+        public int Count { get; set; }
+    }
+
+    /// <summary>
+    /// You.com 结构化联网搜索提供程序。
+    /// 相比现有的HTML抓取+LLM总结方案，You.com直接返回结构化搜索结果，
+    /// 更稳定、更准确。仅当appsettings中配置了YouCom:ApiKey时才启用，
+    /// 未配置或调用失败时返回空字符串，由调用方回退到原有抓取逻辑。
+    /// </summary>
+    public static class YouComSearchProvider
+    {
+        private const string SectionKey = "YouCom";
+        private const int MaxCount = 20;
+        private const int DefaultCount = 10;
+
+        /// <summary>
+        /// 是否已启用You.com搜索（ApiKey非空）
+        /// </summary>
+        public static bool IsEnabled
+        {
+            get
+            {
+                var setting = GetSetting();
+                return setting != null && !string.IsNullOrWhiteSpace(setting.ApiKey);
+            }
+        }
+
+        /// <summary>
+        /// 调用You.com搜索接口并返回格式化后的搜索结果文本。
+        /// 任何异常或空结果都会被吞掉并返回空字符串，确保调用方可以安全回退。
+        /// </summary>
+        /// <param name="query">用户搜索意图问题</param>
+        public static async Task<string> SearchAsync(string query)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return string.Empty;
+            }
+
+            var setting = GetSetting();
+            if (setting == null || string.IsNullOrWhiteSpace(setting.ApiKey) || string.IsNullOrWhiteSpace(setting.Url))
+            {
+                return string.Empty;
+            }
+
+            var count = setting.Count <= 0 ? DefaultCount : Math.Min(setting.Count, MaxCount);
+
+            try
+            {
+                var handler = new HttpClientHandler()
+                {
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli,
+                };
+
+                using var http = new HttpClient(handler);
+                http.Timeout = TimeSpan.FromSeconds(10);
+                // 注意：ApiKey仅用于请求头，绝不打印或记录
+                http.DefaultRequestHeaders.Add("X-API-Key", setting.ApiKey);
+
+                var requestUrl = $"{setting.Url}?query={Uri.EscapeDataString(query)}&count={count}";
+                var response = await http.GetAsync(requestUrl).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    return string.Empty;
+                }
+
+                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return FormatResults(json, count);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"You.com联网搜索请求失败: {ex.Message}");
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// 纯函数：将You.com接口返回的原始JSON映射为结构化的搜索结果文本。
+        /// 不涉及网络请求，便于单元测试。任何解析失败或空结果都返回空字符串。
+        /// </summary>
+        /// <param name="json">You.com接口返回的原始JSON字符串</param>
+        /// <param name="count">最多展示的结果条数（会被限制在MaxCount以内）</param>
+        public static string FormatResults(string json, int count)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return string.Empty;
+            }
+
+            YouComSearchResponse? data;
+            try
+            {
+                data = JsonSerializer.Deserialize<YouComSearchResponse>(json, JsonOptions);
+            }
+            catch (JsonException)
+            {
+                return string.Empty;
+            }
+
+            var webResults = data?.Results?.Web;
+            if (webResults == null || webResults.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var effectiveCount = count <= 0 ? DefaultCount : Math.Min(count, MaxCount);
+            effectiveCount = Math.Min(effectiveCount, webResults.Count);
+
+            var sb = new System.Text.StringBuilder();
+            for (var i = 0; i < effectiveCount; i++)
+            {
+                var item = webResults[i];
+                var title = string.IsNullOrWhiteSpace(item.Title) ? "无标题" : item.Title;
+                sb.AppendLine($"{i + 1}. {title}");
+
+                if (!string.IsNullOrWhiteSpace(item.Url))
+                {
+                    sb.AppendLine($"链接: {item.Url}");
+                }
+
+                if (!string.IsNullOrWhiteSpace(item.Description))
+                {
+                    sb.AppendLine($"描述: {item.Description}");
+                }
+
+                if (item.Snippets != null && item.Snippets.Count > 0)
+                {
+                    var validSnippets = item.Snippets.Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+                    if (validSnippets.Count > 0)
+                    {
+                        sb.AppendLine("摘要:");
+                        foreach (var snippet in validSnippets)
+                        {
+                            sb.AppendLine($"- {snippet}");
+                        }
+                    }
+                }
+
+                sb.AppendLine();
+            }
+
+            sb.Append("信息来源: You.com");
+
+            return sb.ToString();
+        }
+
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        };
+
+        private static YouComSetting? GetSetting()
+        {
+            if (ConfigHelper.Configuration == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return ConfigHelper.GetSection<YouComSetting>(SectionKey);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private class YouComSearchResponse
+        {
+            [JsonPropertyName("results")]
+            public YouComResults? Results { get; set; }
+        }
+
+        private class YouComResults
+        {
+            [JsonPropertyName("web")]
+            public List<YouComWebResult>? Web { get; set; }
+        }
+
+        private class YouComWebResult
+        {
+            [JsonPropertyName("title")]
+            public string? Title { get; set; }
+
+            [JsonPropertyName("url")]
+            public string? Url { get; set; }
+
+            [JsonPropertyName("description")]
+            public string? Description { get; set; }
+
+            [JsonPropertyName("snippets")]
+            public List<string>? Snippets { get; set; }
+        }
+    }
+}

--- a/Test/Kevin.Web.Test/Kevin.Module/YouComSearchProviderTests.cs
+++ b/Test/Kevin.Web.Test/Kevin.Module/YouComSearchProviderTests.cs
@@ -1,0 +1,201 @@
+﻿using kevin.AI.AgentFramework.Tools;
+
+namespace Kevin.Unit.Tests.Kevin.Module
+{
+    /// <summary>
+    /// YouComSearchProvider 单元测试。
+    /// 只覆盖纯函数FormatResults（JSON->格式化文本），不发起真实网络请求，
+    /// 因此无需mock即可离线运行。SearchAsync的联网调用见下方的live-gated测试。
+    /// </summary>
+    public class YouComSearchProviderTests
+    {
+        [Fact]
+        public void FormatResults_WithWebResults_ShouldReturnNumberedText()
+        {
+            // Arrange
+            var json = @"{
+                ""results"": {
+                    ""web"": [
+                        {
+                            ""title"": ""标题一"",
+                            ""url"": ""https://example.com/1"",
+                            ""description"": ""描述一"",
+                            ""snippets"": [""摘要片段A"", ""摘要片段B""]
+                        },
+                        {
+                            ""title"": ""标题二"",
+                            ""url"": ""https://example.com/2"",
+                            ""description"": ""描述二"",
+                            ""snippets"": [""摘要片段C""]
+                        }
+                    ]
+                }
+            }";
+
+            // Act
+            var result = YouComSearchProvider.FormatResults(json, 10);
+
+            // Assert
+            Assert.Contains("1. 标题一", result);
+            Assert.Contains("链接: https://example.com/1", result);
+            Assert.Contains("描述: 描述一", result);
+            Assert.Contains("- 摘要片段A", result);
+            Assert.Contains("- 摘要片段B", result);
+            Assert.Contains("2. 标题二", result);
+            Assert.Contains("信息来源: You.com", result);
+        }
+
+        [Fact]
+        public void FormatResults_WithMissingOptionalFields_ShouldNotThrowAndSkipMissingParts()
+        {
+            // Arrange: url/description/snippets都缺失，只有title
+            var json = @"{
+                ""results"": {
+                    ""web"": [
+                        { ""title"": ""仅有标题"" }
+                    ]
+                }
+            }";
+
+            // Act
+            var result = YouComSearchProvider.FormatResults(json, 10);
+
+            // Assert
+            Assert.Contains("1. 仅有标题", result);
+            Assert.DoesNotContain("链接:", result);
+            Assert.DoesNotContain("描述:", result);
+            Assert.DoesNotContain("摘要:", result);
+            Assert.Contains("信息来源: You.com", result);
+        }
+
+        [Fact]
+        public void FormatResults_WithCompletelyMissingTitle_ShouldUsePlaceholder()
+        {
+            // Arrange
+            var json = @"{ ""results"": { ""web"": [ { ""url"": ""https://example.com"" } ] } }";
+
+            // Act
+            var result = YouComSearchProvider.FormatResults(json, 10);
+
+            // Assert
+            Assert.Contains("1. 无标题", result);
+        }
+
+        [Fact]
+        public void FormatResults_WithEmptyWebArray_ShouldReturnEmptyString()
+        {
+            // Arrange
+            var json = @"{ ""results"": { ""web"": [] } }";
+
+            // Act
+            var result = YouComSearchProvider.FormatResults(json, 10);
+
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void FormatResults_WithNoWebKey_ShouldReturnEmptyString()
+        {
+            // Arrange: news-only结果，没有web字段
+            var json = @"{ ""results"": { ""news"": [] } }";
+
+            // Act
+            var result = YouComSearchProvider.FormatResults(json, 10);
+
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void FormatResults_WithMalformedJson_ShouldReturnEmptyStringWithoutThrow()
+        {
+            // Arrange
+            var malformedJson = "{ this is not valid json ";
+
+            // Act
+            var result = YouComSearchProvider.FormatResults(malformedJson, 10);
+
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void FormatResults_WithNullOrEmptyJson_ShouldReturnEmptyString()
+        {
+            Assert.Equal(string.Empty, YouComSearchProvider.FormatResults("", 10));
+            Assert.Equal(string.Empty, YouComSearchProvider.FormatResults(null!, 10));
+        }
+
+        [Fact]
+        public void FormatResults_ShouldCapResultCountAtRequestedCount()
+        {
+            // Arrange: 5条结果，但请求只展示2条
+            var items = string.Join(",", Enumerable.Range(1, 5).Select(i =>
+                $@"{{ ""title"": ""标题{i}"", ""url"": ""https://example.com/{i}"" }}"));
+            var json = $@"{{ ""results"": {{ ""web"": [{items}] }} }}";
+
+            // Act
+            var result = YouComSearchProvider.FormatResults(json, 2);
+
+            // Assert
+            Assert.Contains("1. 标题1", result);
+            Assert.Contains("2. 标题2", result);
+            Assert.DoesNotContain("3. 标题3", result);
+        }
+
+        [Fact]
+        public void FormatResults_ShouldNeverExceedHardCapOfTwenty()
+        {
+            // Arrange: 25条结果，请求count=25，应被限制在20条以内
+            var items = string.Join(",", Enumerable.Range(1, 25).Select(i =>
+                $@"{{ ""title"": ""标题{i}"", ""url"": ""https://example.com/{i}"" }}"));
+            var json = $@"{{ ""results"": {{ ""web"": [{items}] }} }}";
+
+            // Act
+            var result = YouComSearchProvider.FormatResults(json, 25);
+
+            // Assert
+            Assert.Contains("20. 标题20", result);
+            Assert.DoesNotContain("21. 标题21", result);
+        }
+
+        [Fact]
+        public void IsEnabled_WithoutInitializedConfiguration_ShouldBeFalse()
+        {
+            // Arrange & Act: 单元测试进程中未调用ConfigHelper.Initialize，
+            // Configuration应为空，IsEnabled必须安全地返回false而不是抛异常。
+            var isEnabled = YouComSearchProvider.IsEnabled;
+
+            // Assert
+            Assert.False(isEnabled);
+        }
+
+        [Fact]
+        public async Task SearchAsync_LiveCall_ShouldReturnStructuredResultsWhenKeyConfigured()
+        {
+            // 联网门控测试：仅当环境变量YDC_API_KEY存在时才真正发起一次真实调用。
+            // 未设置时直接跳过（早返回），不消耗任何API调用额度。
+            var apiKey = Environment.GetEnvironmentVariable("YDC_API_KEY");
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                return;
+            }
+
+            // 直接调用You.com接口验证真实响应能被正确格式化（不依赖ConfigHelper/appsettings）。
+            var handler = new HttpClientHandler();
+            using var http = new HttpClient(handler);
+            http.Timeout = TimeSpan.FromSeconds(15);
+            http.DefaultRequestHeaders.Add("X-API-Key", apiKey);
+            var response = await http.GetAsync("https://ydc-index.io/v1/search?query=You.com&count=3");
+
+            Assert.True(response.IsSuccessStatusCode, $"You.com接口调用失败: {(int)response.StatusCode}");
+
+            var json = await response.Content.ReadAsStringAsync();
+            var formatted = YouComSearchProvider.FormatResults(json, 3);
+
+            Assert.False(string.IsNullOrEmpty(formatted));
+            Assert.Contains("信息来源: You.com", formatted);
+        }
+    }
+}

--- a/Test/Kevin.Web.Test/Kevin.Unit.Tests.csproj
+++ b/Test/Kevin.Web.Test/Kevin.Unit.Tests.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Kevin\Kevin.Web.Basics\Kevin.Web.Basics.csproj" />
     <ProjectReference Include="..\..\Kevin\kevin.Module\Kevin.RAG\Kevin.RAG.csproj" />
+    <ProjectReference Include="..\..\Kevin\kevin.Module\kevin.AI.AgentFramework\kevin.AI.AgentFramework.csproj" />
     <ProjectReference Include="..\Testing.Shared\Kevin.Testing.Shared.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
关联 Issue: https://github.com/junkai-li/NetCoreKevin/issues/12

## 动机

现有的联网搜索（`HttpClientFunction.GetSeoAsync`）通过抓取必应/百度/搜狗/360 结果页 HTML、再用大模型清洗总结，依赖页面结构、易受反爬与编码问题影响。本 PR 将 **You.com Search API** 注册为结构化的联网搜索提供程序：配置 Key 时优先使用 You.com 的结构化结果，未配置或调用失败时**自动回退**到原有抓取逻辑。纯增量、带回退，不改变默认行为。

## 变更内容

- 新增 `Tools/YouComSearchProvider`（kevin.AI.AgentFramework）：
  - `SearchAsync(query)` 负责网络请求（`GET https://ydc-index.io/v1/search`，`X-API-Key` 头，10s 超时，自动解压）；
  - `FormatResults(json, count)` 是**纯函数**，负责把 JSON 映射为结构化文本（标题/链接/描述/摘要 + 来源），便于离线单元测试；
  - `IsEnabled` 依据 `appsettings` 的 `YouCom:ApiKey` 是否配置；数量上限 20；任何异常/空结果都返回空字符串，保证调用方安全回退；API Key 绝不打印或记录。
- `HttpClientFunction.GetSeoAsync` 顶部：启用且返回非空时优先返回 You.com 结果（保持原有 `互联网查询信息:` 返回结构不变），否则原样走既有抓取流程。**方法签名不变，调用方无需改动，抓取逻辑完整保留。**
- `appsettings.json`（及 Development/Test）新增 `YouCom` 段（ApiKey 留空 / Url / Count），经现有 `ConfigHelper` 读取。

## 测试

- 新增 `YouComSearchProviderTests`：11 个用例，覆盖结果映射（正常/缺字段/空结果/数量上限/异常 JSON 不抛出）等，**离线全过**；含一个环境变量门控的在线用例（设置 `YDC_API_KEY` 后实测通过，返回真实结构化结果）。
- 全量单元测试与 master 基线对比：新增 11 个全部通过，零回归。

```bash
cd Test/Kevin.Web.Test
dotnet test --filter "FullyQualifiedName~YouCom"
# 在线（可选，1 次真实调用）
export YDC_API_KEY=<你的 Key>   # 获取: https://you.com/platform/api-keys
```

## 备注

- 刻意保留原有多引擎抓取作为回退，未做删除，最大限度降低风险。
- 应用整体启动依赖 MySQL/Redis 等，未在本地启动；证据为映射单元测试 + 一次真实 API 调用。

---

**English summary**: Registers You.com as a structured web-search provider. New YouComSearchProvider with a network method and a pure, unit-testable FormatResults mapper (GET ydc-index.io/v1/search, X-API-Key, results.web[] -> structured text). Wired into GetSeoAsync as the preferred provider when a YouCom:ApiKey is configured, with the existing 5-engine HTML-scrape kept as fallback — signature unchanged, callers untouched, additive and zero-risk. 11 unit tests (offline mapper coverage + one env-gated live test verified against the real API), zero regressions, no new NuGet packages, key never logged.
